### PR TITLE
Jww json file open update

### DIFF
--- a/tap_peek/peek.py
+++ b/tap_peek/peek.py
@@ -9,18 +9,6 @@ import singer
 from datetime import datetime, timezone
 
 
-# with open('./tap_peek/activity_info_schema.json') as json_file:
-#     activity_info_schema = json.load(json_file)
-
-
-# with open('./tap_peek/core_addons_schema.json') as json_file:
-#     core_addons_schema = json.load(json_file)
-
-
-# with open('./tap_peek/timeslots_schema.json') as json_file:
-#     timeslots_schema = json.load(json_file)
-
-
 pp = pprint.PrettyPrinter(indent=4, depth=3)
 
 # args = singer.utils.parse_args(["token", "partner_id"])


### PR DESCRIPTION
# Description :: User Story

This PR changes how the `json` schemas are opened.
* All schemas are now opened only in their respective function
* This prevents unnecessary schemas from being loaded

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [ ] Testing

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes

Details:

## Pull Request Notes

Add any notes here.

## Pytest Results and Coverage

Normalized test coverage is 100%.

```txt
---------- coverage: platform darwin, python 3.8.2-final-0 -----------
Name                   Stmts   Miss  Cover   Missing
----------------------------------------------------
tap_peek/__init__.py       1      0   100%
tap_peek/peek.py          58      5    91%   43-53, 82
----------------------------------------------------
TOTAL                     59      5    92%
```
