### PR TITLE
Fix primary key of timeslots

### DIFF
--- a/tap_peek/streams.py
+++ b/tap_peek/streams.py
@@ -78,7 +78,7 @@ class Transactions(CatalogStream):
 
 class Timeslots(CatalogStream):
     tap_stream_id  = 'timeslots'
-    key_properties = ['id']
+    key_properties = ['fid']
     object_type    = 'TIMESLOT'
 
     def sync(self, partner_id=None, start_date=None, end_date=None, *args, **kwargs):


### PR DESCRIPTION
# Description :: User Story

The primary key for the `timeslots` table was wrong. This is a fix.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes

Details:

## Pull Request Notes

None

## Pytest Results and Coverage

```txt
No changes
```
